### PR TITLE
[hotfix] Recreate styling of 'Add a card...' text on hover

### DIFF
--- a/browser/components/BoardShowPage.sass
+++ b/browser/components/BoardShowPage.sass
@@ -77,3 +77,4 @@
     &:hover
       cursor: pointer
       background-color: rgba(0,0,0,0.2)
+      text-decoration: underline


### PR DESCRIPTION
On hover, Trello underlines the 'Add a card...' text found at the
bottom of each list. Now Trossello does, too.
