### PR TITLE
persist the card content in session

### DIFF
--- a/browser/components/BoardShowPage/EditCardForm.js
+++ b/browser/components/BoardShowPage/EditCardForm.js
@@ -8,6 +8,8 @@ import ArchiveButton from './ArchiveButton'
 import $ from 'jquery'
 import boardStore from '../../stores/boardStore'
 import autosize from 'autosize'
+import sessionStorage from '../../sessionStorage'
+const KEY = "EditCardFormContent"
 
 export default class EditCardForm extends Component {
 
@@ -32,7 +34,9 @@ export default class EditCardForm extends Component {
   }
 
   initialContentValue(props){
-    return props.defaultValue || (props.card && props.card.content) || ''
+    return this.props.card ?
+      this.props.card.content || '' :
+      sessionStorage[KEY] || ''
   }
 
   componentDidMount() {
@@ -53,11 +57,18 @@ export default class EditCardForm extends Component {
   }
 
   onContentChange(event){
-    this.setState({content: event.target.value})
+    const cardContent = event.target.value
+    if (!this.props.card) {
+      sessionStorage[KEY] = cardContent
+    }
+    this.setState({content: cardContent})
   }
 
   save(event){
     if (event) event.preventDefault()
+    if (!this.props.card) {
+      delete sessionStorage[KEY]
+    }
     this.props.onSave({
       content: this.state.content.replace(/[\n\s]+$/, ''),
     })
@@ -67,9 +78,11 @@ export default class EditCardForm extends Component {
   }
 
   cancel(event){
+    if (!this.props.card) {
+      delete sessionStorage[KEY]
+    }
     this.props.onCancel(event)
   }
-
 
   render() {
     const closeX = this.props.hideCloseX ? null :

--- a/browser/sessionStorage.js
+++ b/browser/sessionStorage.js
@@ -1,0 +1,1 @@
+export default window.sessionStorage || {}


### PR DESCRIPTION
Move session update before ajax call in create card | Call event.target.value only once in onContentChange in EditCardForm

change session value to only change on creating new

remove spaces

make sessionstorage compatible with older browsers