### PR TITLE
WIP: Add check to prevent searchbar from activating when focus is in Search Textarea

### DIFF
--- a/browser/components/CardSearchForm.js
+++ b/browser/components/CardSearchForm.js
@@ -141,7 +141,11 @@ class SearchResultModal extends Component {
 
   closeIfUserClickedElsewhere(event){
     const container = ReactDOM.findDOMNode(this.refs.window)
-    if (!container.contains(event.target) && container !== event.target) {
+    if (
+      !container.contains(event.target) &&
+      container !== event.target &&
+      event.target.className !== "CardSearchForm-Input"
+    ) {
       this.props.onClose()
     }
   }


### PR DESCRIPTION
Existing issues: 
*Clicking the "x" in search bar will occasionally exit focus but leave text in box. Cannot reproduce consistently (appears to be random!)
*Clicking on the lower right corner of the search bar, but very very close to search bar, will close focus of search bar yet leave text there.
*Code for checking is relying on class-name. What if class name changes later? Can we "get" a ReactDOM token/artifact/entity instead?