### PR TITLE
Allows new users to log in correctly

### DIFF
--- a/server/database/commands.js
+++ b/server/database/commands.js
@@ -143,10 +143,14 @@ const findOrCreateUserFromGithubProfile = (githubProfile) => {
 
 const createUser = (attributes) =>
   createRecord('users', attributes)
-    .then(user =>
-      mailer.sendWelcomeEmail(user)
-        .then(() => user )
-    )
+    .then(user => {
+      if( user.email ){
+        mailer.sendWelcomeEmail(user)
+          .then(() => user )
+      } else {
+        return user
+      }
+    })
 
 const updateUser = (id, attributes) =>{
   attributes.updated_at = new Date()


### PR DESCRIPTION
The send email function was causing errors because new users logging in normally are not required to submit their email.